### PR TITLE
Updated env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To reproduce the results of the study, two repositories originally written by th
 
 It will also include an extension. Currently a work in progress as we gather ideas.
 
-This project is a so called "Project Module", part of the [Cogniive Systems](https://www.uni-potsdam.de/en/studium/what-to-study/master/masters-courses-from-a-to-z/cognitive-systems) Master program at the [University of Potsdam](https://www.uni-potsdam.de/en/university-of-potsdam). Contributors: [Tamara Atanasoska](https://github.com/TamaraAtanasoska), [Emanuele De Rossi](https://github.com/EmanueleDeRossi1) and [Galina Ryazanskaya](https://github.com/flying-bear).
+This project is a so called "Project Module", part of the [Cognitive Systems](https://www.uni-potsdam.de/en/studium/what-to-study/master/masters-courses-from-a-to-z/cognitive-systems) Master program at the [University of Potsdam](https://www.uni-potsdam.de/en/university-of-potsdam). Contributors: [Tamara Atanasoska](https://github.com/TamaraAtanasoska), [Emanuele De Rossi](https://github.com/EmanueleDeRossi1) and [Galina Ryazanskaya](https://github.com/flying-bear).
 
 ## Setup
 

--- a/setup/conda.yml
+++ b/setup/conda.yml
@@ -61,7 +61,7 @@ dependencies:
     - pyqt5==5.15.7
     - pyqt5-qt5==5.15.2
     - pyqt5-sip==12.11.0
-    - python-graphviz==0.20.1
+    - graphviz==0.20.1
     - pyyaml==6.0
     - regex==2022.10.31
     - requests==2.28.1

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -2,7 +2,7 @@ amrlib==0.7.1
 blis==0.7.9
 cached-property==1.5.2
 catalogue==2.0.8
-certifi @ file:///private/var/folders/sy/f16zz6x50xz3113nwtb9bvq00000gp/T/abs_0ek9yztvu3/croot/certifi_1665076692562/work/certifi
+certifi==2022.9.24
 charset-normalizer==2.1.1
 click==8.1.3
 confection==0.0.3
@@ -16,15 +16,16 @@ joblib==1.2.0
 langcodes==3.3.0
 MarkupSafe==2.1.1
 mkl-fft==1.3.1
-mkl-random @ file:///opt/concourse/worker/volumes/live/a9eca864-069c-4240-73c8-4e51b036a10d/volume/mkl_random_1639994047876/work
+mkl-random==1.2.2
 mkl-service==2.4.0
 murmurhash==1.0.9
 networkx==2.8.8
 nltk==3.7
-numpy @ file:///private/var/folders/sy/f16zz6x50xz3113nwtb9bvq00000gp/T/abs_f1fp12zi4u/croot/numpy_and_numpy_base_1667233468135/work
+numpy==1.23.3
 packaging==21.3
 pathy==0.7.1
 Penman==1.2.2
+pip==22.2.2
 preshed==3.0.8
 pydantic==1.10.2
 pyparsing==3.0.9
@@ -36,7 +37,8 @@ regex==2022.10.31
 requests==2.28.1
 scikit-learn==1.1.3
 scipy==1.9.3
-six @ file:///tmp/build/80754af9/six_1644875935023/work
+setuptools==65.5.0
+six==1.16.0
 sklearn==0.0.post1
 smart-open==5.2.1
 smatch==1.0.4
@@ -55,4 +57,5 @@ typing_extensions==4.4.0
 Unidecode==1.3.6
 urllib3==1.26.12
 wasabi==0.10.1
+wheel==0.37.1
 word2number==1.1


### PR DESCRIPTION
This PR fixes two issues:
- the incorrect paths pip freeze has generated (instead using the `pip list --format=freeze > requirements.txt` command now)
- changing `python-graphviz` to `graphviz` in the conda env generation file so pip can find it

Bonus:
- fixed a typo 