### PR TITLE
Fixing a wrong name referring to the learning rate in the sweep config

### DIFF
--- a/conclusion_generation/fine_tuning/fine-tune.py
+++ b/conclusion_generation/fine_tuning/fine-tune.py
@@ -203,7 +203,7 @@ if __name__ == "__main__":
             "metric": {"goal": "minimize", "name": "train_loss"},
             "parameters": {
                 "train_epochs": {"values": [5, 10, 15, 20]},
-                "lr": {"values": [0.1, 0.003, 0.001, 0.0003, 0.0001]},
+                "learning_rate": {"values": [0.1, 0.003, 0.001, 0.0003, 0.0001]},
                 "gamma": {"values": [1.0, 0.9, 0.7, 0.5, 0.3]},
             },
         }


### PR DESCRIPTION
This PR fixes a wrong config name that refers to the learning rate in the sweep config